### PR TITLE
feat(video-routing): route real shot specs across direct/parallel/sequential

### DIFF
--- a/src/video_validation/__init__.py
+++ b/src/video_validation/__init__.py
@@ -6,10 +6,13 @@ from .multisubject_router import (
     RoutingDecision,
     route_multi_subject_shot,
 )
+from .shot_spec_adapter import extract_multi_subject_shot, route_shot_spec
 
 __all__ = [
     "GenerationStrategy",
     "MultiSubjectShot",
     "RoutingDecision",
     "route_multi_subject_shot",
+    "extract_multi_subject_shot",
+    "route_shot_spec",
 ]

--- a/src/video_validation/__init__.py
+++ b/src/video_validation/__init__.py
@@ -1,0 +1,15 @@
+"""Video validation and generation-routing primitives for StoryCore."""
+
+from .multisubject_router import (
+    GenerationStrategy,
+    MultiSubjectShot,
+    RoutingDecision,
+    route_multi_subject_shot,
+)
+
+__all__ = [
+    "GenerationStrategy",
+    "MultiSubjectShot",
+    "RoutingDecision",
+    "route_multi_subject_shot",
+]

--- a/src/video_validation/multisubject_router.py
+++ b/src/video_validation/multisubject_router.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class GenerationStrategy(str, Enum):
+    DIRECT = "DIRECT"
+    PARALLEL = "PARALLEL"
+    SEQUENTIAL = "SEQUENTIAL"
+
+
+@dataclass(frozen=True)
+class MultiSubjectShot:
+    subject_count: int
+    interaction_strength: float = 0.0
+    contact_required: bool = False
+    occlusion_level: float = 0.0
+    identity_criticality: float = 0.5
+    camera_motion: float = 0.0
+    temporal_dependency: float = 0.0
+    compute_budget: float = 0.5
+
+    def __post_init__(self) -> None:
+        if self.subject_count < 0:
+            raise ValueError("subject_count must be non-negative")
+        for name in (
+            "interaction_strength",
+            "occlusion_level",
+            "identity_criticality",
+            "camera_motion",
+            "temporal_dependency",
+            "compute_budget",
+        ):
+            value = getattr(self, name)
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    strategy: GenerationStrategy
+    confidence: float
+    reasons: tuple[str, ...]
+    requires_intermediate_validation: bool
+
+
+def route_multi_subject_shot(shot: MultiSubjectShot) -> RoutingDecision:
+    """Choose a generation strategy using deterministic, explainable rules.
+
+    The router does not call a model and does not generate media. It only
+    chooses the safest/cheapest generation topology for the supplied shot
+    complexity. Downstream validators still decide whether the result passes.
+    """
+
+    reasons: list[str] = []
+
+    if shot.subject_count <= 1:
+        return RoutingDecision(
+            strategy=GenerationStrategy.DIRECT,
+            confidence=0.98,
+            reasons=("single_or_no_subject",),
+            requires_intermediate_validation=False,
+        )
+
+    # Strong physical/spatial coupling is the clearest case for staged
+    # generation because independent branches cannot reliably preserve contact.
+    if shot.contact_required:
+        reasons.append("contact_required")
+    if shot.interaction_strength >= 0.7:
+        reasons.append("strong_subject_interaction")
+    if shot.occlusion_level >= 0.75:
+        reasons.append("heavy_occlusion")
+    if shot.temporal_dependency >= 0.8:
+        reasons.append("strong_temporal_dependency")
+
+    if reasons:
+        confidence = min(0.98, 0.80 + 0.04 * len(reasons))
+        return RoutingDecision(
+            strategy=GenerationStrategy.SEQUENTIAL,
+            confidence=confidence,
+            reasons=tuple(reasons),
+            requires_intermediate_validation=True,
+        )
+
+    # Independent subjects with high identity requirements benefit from
+    # separate generation branches followed by composition/reconciliation.
+    parallel_score = 0.0
+    if shot.identity_criticality >= 0.7:
+        parallel_score += 0.45
+        reasons.append("identity_critical")
+    if shot.subject_count >= 3:
+        parallel_score += 0.25
+        reasons.append("many_subjects")
+    if shot.interaction_strength <= 0.35:
+        parallel_score += 0.20
+        reasons.append("weak_subject_interaction")
+    if shot.occlusion_level <= 0.35:
+        parallel_score += 0.10
+        reasons.append("low_occlusion")
+
+    if parallel_score >= 0.65:
+        return RoutingDecision(
+            strategy=GenerationStrategy.PARALLEL,
+            confidence=min(0.95, 0.70 + parallel_score * 0.25),
+            reasons=tuple(reasons),
+            requires_intermediate_validation=True,
+        )
+
+    # Complex camera motion and previous-shot continuity can still favor a
+    # staged build even without direct contact between subjects.
+    if shot.camera_motion >= 0.75 and shot.temporal_dependency >= 0.55:
+        return RoutingDecision(
+            strategy=GenerationStrategy.SEQUENTIAL,
+            confidence=0.78,
+            reasons=("camera_motion_with_temporal_dependency",),
+            requires_intermediate_validation=True,
+        )
+
+    # When compute is severely constrained, use the single-pass baseline and
+    # rely on validators rather than multiplying generation branches.
+    if shot.compute_budget <= 0.2:
+        return RoutingDecision(
+            strategy=GenerationStrategy.DIRECT,
+            confidence=0.72,
+            reasons=("compute_budget_constrained",),
+            requires_intermediate_validation=False,
+        )
+
+    return RoutingDecision(
+        strategy=GenerationStrategy.DIRECT,
+        confidence=0.70,
+        reasons=("low_interaction_complexity",),
+        requires_intermediate_validation=False,
+    )

--- a/src/video_validation/shot_spec_adapter.py
+++ b/src/video_validation/shot_spec_adapter.py
@@ -49,6 +49,14 @@ def _normalize_score(value: Any, *, name: str, default: float) -> float:
     return score
 
 
+def _normalize_bool(value: Any, *, name: str, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be boolean")
+    return value
+
+
 def _camera_motion_score(value: Any) -> float:
     if value is None:
         return 0.0
@@ -109,7 +117,9 @@ def extract_multi_subject_shot(
         interaction_strength=_normalize_score(
             routing.get("interaction_strength"), name="interaction_strength", default=0.0
         ),
-        contact_required=bool(routing.get("contact_required", False)),
+        contact_required=_normalize_bool(
+            routing.get("contact_required"), name="contact_required", default=False
+        ),
         occlusion_level=_normalize_score(
             routing.get("occlusion_level"), name="occlusion_level", default=0.0
         ),

--- a/src/video_validation/shot_spec_adapter.py
+++ b/src/video_validation/shot_spec_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -44,8 +45,8 @@ def _normalize_score(value: Any, *, name: str, default: float) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError(f"{name} must be numeric")
     score = float(value)
-    if not 0.0 <= score <= 1.0:
-        raise ValueError(f"{name} must be in [0, 1]")
+    if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+        raise ValueError(f"{name} must be finite and in [0, 1]")
     return score
 
 
@@ -70,24 +71,37 @@ def _camera_motion_score(value: Any) -> float:
     return max(matched, default=0.25 if normalized.strip() else 0.0)
 
 
+def _sequence_count(value: Any) -> int | None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return len(value)
+    return None
+
+
 def _subject_count(shot_spec: Any, *, subjects: Sequence[Any] | None, routing: Mapping[str, Any]) -> int:
+    candidates: list[tuple[str, int]] = []
+
     explicit = routing.get("subject_count", _read(shot_spec, "subject_count", None))
     if explicit is not None:
         if isinstance(explicit, bool) or not isinstance(explicit, int) or explicit < 0:
             raise ValueError("subject_count must be a non-negative integer")
-        return explicit
+        candidates.append(("subject_count", explicit))
 
     for key in ("characters_present", "subjects", "characters"):
-        value = _read(shot_spec, key, None)
-        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-            return len(value)
+        count = _sequence_count(_read(shot_spec, key, None))
+        if count is not None:
+            candidates.append((key, count))
 
     if subjects is not None:
-        return len(subjects)
+        candidates.append(("subjects_argument", len(subjects)))
 
-    # Fail closed rather than silently treating an unknown multi-character shot
-    # as a single-subject DIRECT generation.
-    raise ValueError("subject_count is required when the shot spec has no subject list")
+    if not candidates:
+        raise ValueError("subject_count is required when the shot spec has no subject list")
+
+    distinct = {count for _, count in candidates}
+    if len(distinct) != 1:
+        detail = ", ".join(f"{name}={count}" for name, count in candidates)
+        raise ValueError(f"contradictory subject counts: {detail}")
+    return candidates[0][1]
 
 
 def extract_multi_subject_shot(

--- a/src/video_validation/shot_spec_adapter.py
+++ b/src/video_validation/shot_spec_adapter.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .multisubject_router import MultiSubjectShot, RoutingDecision, route_multi_subject_shot
+
+
+_CAMERA_MOTION_INTENSITY = {
+    "static": 0.0,
+    "locked": 0.0,
+    "none": 0.0,
+    "pan": 0.35,
+    "tilt": 0.35,
+    "zoom": 0.45,
+    "dolly": 0.55,
+    "tracking": 0.6,
+    "truck": 0.6,
+    "pedestal": 0.55,
+    "orbit": 0.75,
+    "crane": 0.75,
+    "handheld": 0.8,
+    "whip": 0.9,
+}
+
+
+def _read(source: Any, key: str, default: Any = None) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(key, default)
+    return getattr(source, key, default)
+
+
+def _routing_metadata(shot_spec: Any) -> Mapping[str, Any]:
+    metadata = _read(shot_spec, "metadata", {})
+    if not isinstance(metadata, Mapping):
+        return {}
+    routing = metadata.get("multi_subject_routing", {})
+    return routing if isinstance(routing, Mapping) else {}
+
+
+def _normalize_score(value: Any, *, name: str, default: float) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    score = float(value)
+    if not 0.0 <= score <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return score
+
+
+def _camera_motion_score(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _normalize_score(value, name="camera_motion", default=0.0)
+    if not isinstance(value, str):
+        raise ValueError("camera_motion must be numeric or text")
+
+    normalized = value.lower().replace("-", " ").replace("_", " ")
+    matched = [score for token, score in _CAMERA_MOTION_INTENSITY.items() if token in normalized]
+    return max(matched, default=0.25 if normalized.strip() else 0.0)
+
+
+def _subject_count(shot_spec: Any, *, subjects: Sequence[Any] | None, routing: Mapping[str, Any]) -> int:
+    explicit = routing.get("subject_count", _read(shot_spec, "subject_count", None))
+    if explicit is not None:
+        if isinstance(explicit, bool) or not isinstance(explicit, int) or explicit < 0:
+            raise ValueError("subject_count must be a non-negative integer")
+        return explicit
+
+    for key in ("characters_present", "subjects", "characters"):
+        value = _read(shot_spec, key, None)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return len(value)
+
+    if subjects is not None:
+        return len(subjects)
+
+    # Fail closed rather than silently treating an unknown multi-character shot
+    # as a single-subject DIRECT generation.
+    raise ValueError("subject_count is required when the shot spec has no subject list")
+
+
+def extract_multi_subject_shot(
+    shot_spec: Any,
+    *,
+    subjects: Sequence[Any] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> MultiSubjectShot:
+    """Adapt an existing StoryCore shot/dict into the deterministic routing contract.
+
+    Rich routing metadata can live under ``metadata.multi_subject_routing``.
+    ``overrides`` is intended for the orchestration layer when scene context knows
+    more than the shot object itself. No NLP guessing is performed here.
+    """
+
+    routing = dict(_routing_metadata(shot_spec))
+    if overrides:
+        routing.update(overrides)
+
+    camera_value = routing.get(
+        "camera_motion",
+        _read(shot_spec, "camera_movement", _read(shot_spec, "camera_motion", None)),
+    )
+
+    return MultiSubjectShot(
+        subject_count=_subject_count(shot_spec, subjects=subjects, routing=routing),
+        interaction_strength=_normalize_score(
+            routing.get("interaction_strength"), name="interaction_strength", default=0.0
+        ),
+        contact_required=bool(routing.get("contact_required", False)),
+        occlusion_level=_normalize_score(
+            routing.get("occlusion_level"), name="occlusion_level", default=0.0
+        ),
+        identity_criticality=_normalize_score(
+            routing.get("identity_criticality"), name="identity_criticality", default=0.5
+        ),
+        camera_motion=_camera_motion_score(camera_value),
+        temporal_dependency=_normalize_score(
+            routing.get("temporal_dependency"), name="temporal_dependency", default=0.0
+        ),
+        compute_budget=_normalize_score(
+            routing.get("compute_budget"), name="compute_budget", default=0.5
+        ),
+    )
+
+
+def route_shot_spec(
+    shot_spec: Any,
+    *,
+    subjects: Sequence[Any] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> RoutingDecision:
+    """Extract a routing input from a StoryCore shot and choose its topology."""
+
+    return route_multi_subject_shot(
+        extract_multi_subject_shot(shot_spec, subjects=subjects, overrides=overrides)
+    )

--- a/tests/test_multi_subject_router.py
+++ b/tests/test_multi_subject_router.py
@@ -1,0 +1,93 @@
+import pytest
+
+from src.video_validation.multisubject_router import (
+    GenerationStrategy,
+    MultiSubjectShot,
+    route_multi_subject_shot,
+)
+
+
+def test_single_subject_uses_direct():
+    decision = route_multi_subject_shot(MultiSubjectShot(subject_count=1))
+    assert decision.strategy == GenerationStrategy.DIRECT
+    assert decision.requires_intermediate_validation is False
+
+
+def test_contact_required_uses_sequential():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(subject_count=2, contact_required=True)
+    )
+    assert decision.strategy == GenerationStrategy.SEQUENTIAL
+    assert "contact_required" in decision.reasons
+    assert decision.requires_intermediate_validation is True
+
+
+def test_strong_interaction_uses_sequential():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(subject_count=2, interaction_strength=0.85)
+    )
+    assert decision.strategy == GenerationStrategy.SEQUENTIAL
+    assert "strong_subject_interaction" in decision.reasons
+
+
+def test_identity_critical_independent_subjects_use_parallel():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(
+            subject_count=3,
+            identity_criticality=0.95,
+            interaction_strength=0.1,
+            occlusion_level=0.1,
+        )
+    )
+    assert decision.strategy == GenerationStrategy.PARALLEL
+    assert decision.requires_intermediate_validation is True
+    assert "identity_critical" in decision.reasons
+
+
+def test_camera_motion_plus_continuity_uses_sequential():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(
+            subject_count=2,
+            interaction_strength=0.5,
+            occlusion_level=0.5,
+            identity_criticality=0.5,
+            camera_motion=0.9,
+            temporal_dependency=0.6,
+        )
+    )
+    assert decision.strategy == GenerationStrategy.SEQUENTIAL
+    assert decision.reasons == ("camera_motion_with_temporal_dependency",)
+
+
+def test_simple_two_subject_scene_defaults_direct():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(
+            subject_count=2,
+            interaction_strength=0.45,
+            occlusion_level=0.2,
+            identity_criticality=0.45,
+        )
+    )
+    assert decision.strategy == GenerationStrategy.DIRECT
+    assert decision.reasons == ("low_interaction_complexity",)
+
+
+def test_compute_constrained_scene_can_stay_direct():
+    decision = route_multi_subject_shot(
+        MultiSubjectShot(
+            subject_count=2,
+            interaction_strength=0.4,
+            occlusion_level=0.4,
+            identity_criticality=0.5,
+            compute_budget=0.1,
+        )
+    )
+    assert decision.strategy == GenerationStrategy.DIRECT
+    assert decision.reasons == ("compute_budget_constrained",)
+
+
+def test_invalid_inputs_fail_closed():
+    with pytest.raises(ValueError):
+        MultiSubjectShot(subject_count=-1)
+    with pytest.raises(ValueError):
+        MultiSubjectShot(subject_count=2, interaction_strength=1.1)

--- a/tests/test_shot_spec_router_adapter.py
+++ b/tests/test_shot_spec_router_adapter.py
@@ -87,6 +87,22 @@ def test_routing_metadata_can_override_subject_count_and_budget():
     assert "compute_budget_constrained" in decision.reasons
 
 
+def test_contradictory_subject_counts_fail_closed():
+    spec = {
+        "subject_count": 1,
+        "characters_present": ["hero", "rival", "witness"],
+        "camera_movement": "static",
+    }
+    with pytest.raises(ValueError, match="contradictory subject counts"):
+        route_shot_spec(spec)
+
+
+def test_explicit_subject_argument_must_match_shot_metadata():
+    spec = {"characters_present": ["hero", "rival"], "camera_movement": "static"}
+    with pytest.raises(ValueError, match="contradictory subject counts"):
+        route_shot_spec(spec, subjects=["hero"])
+
+
 def test_invalid_score_fails_closed():
     with pytest.raises(ValueError, match="interaction_strength"):
         extract_multi_subject_shot(
@@ -94,6 +110,16 @@ def test_invalid_score_fails_closed():
             subjects=["a", "b"],
             overrides={"interaction_strength": 1.2},
         )
+
+
+def test_non_finite_score_fails_closed():
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="interaction_strength"):
+            extract_multi_subject_shot(
+                ShotLike(),
+                subjects=["a", "b"],
+                overrides={"interaction_strength": value},
+            )
 
 
 def test_non_boolean_contact_required_fails_closed():

--- a/tests/test_shot_spec_router_adapter.py
+++ b/tests/test_shot_spec_router_adapter.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from src.video_validation.multisubject_router import GenerationStrategy
+from src.video_validation.shot_spec_adapter import (
+    extract_multi_subject_shot,
+    route_shot_spec,
+)
+
+
+@dataclass
+class ShotLike:
+    camera_movement: str = "static"
+    metadata: dict = field(default_factory=dict)
+
+
+def test_single_subject_existing_shot_routes_direct():
+    decision = route_shot_spec(ShotLike(camera_movement="static"), subjects=["hero"])
+    assert decision.strategy is GenerationStrategy.DIRECT
+
+
+def test_scene_characters_present_can_supply_subject_count():
+    spec = {
+        "characters_present": ["hero", "rival"],
+        "camera_movement": "static",
+        "metadata": {
+            "multi_subject_routing": {
+                "contact_required": True,
+                "interaction_strength": 0.9,
+            }
+        },
+    }
+    decision = route_shot_spec(spec)
+    assert decision.strategy is GenerationStrategy.SEQUENTIAL
+    assert decision.requires_intermediate_validation is True
+
+
+def test_identity_critical_independent_subjects_route_parallel():
+    shot = ShotLike(camera_movement="tracking")
+    decision = route_shot_spec(
+        shot,
+        subjects=["a", "b", "c"],
+        overrides={
+            "identity_criticality": 0.95,
+            "interaction_strength": 0.1,
+            "occlusion_level": 0.1,
+        },
+    )
+    assert decision.strategy is GenerationStrategy.PARALLEL
+
+
+def test_camera_motion_text_is_normalized_deterministically():
+    routing_input = extract_multi_subject_shot(
+        ShotLike(camera_movement="fast orbit camera"),
+        subjects=["a", "b"],
+        overrides={"temporal_dependency": 0.7},
+    )
+    assert routing_input.camera_motion == 0.75
+    decision = route_shot_spec(
+        ShotLike(camera_movement="fast orbit camera"),
+        subjects=["a", "b"],
+        overrides={"temporal_dependency": 0.7},
+    )
+    assert decision.strategy is GenerationStrategy.SEQUENTIAL
+
+
+def test_unknown_subject_count_fails_closed():
+    with pytest.raises(ValueError, match="subject_count is required"):
+        route_shot_spec(ShotLike())
+
+
+def test_routing_metadata_can_override_subject_count_and_budget():
+    spec = {
+        "camera_movement": "pan",
+        "metadata": {
+            "multi_subject_routing": {
+                "subject_count": 2,
+                "compute_budget": 0.1,
+                "interaction_strength": 0.4,
+                "occlusion_level": 0.4,
+            }
+        },
+    }
+    decision = route_shot_spec(spec)
+    assert decision.strategy is GenerationStrategy.DIRECT
+    assert "compute_budget_constrained" in decision.reasons
+
+
+def test_invalid_score_fails_closed():
+    with pytest.raises(ValueError, match="interaction_strength"):
+        extract_multi_subject_shot(
+            ShotLike(),
+            subjects=["a", "b"],
+            overrides={"interaction_strength": 1.2},
+        )

--- a/tests/test_shot_spec_router_adapter.py
+++ b/tests/test_shot_spec_router_adapter.py
@@ -94,3 +94,12 @@ def test_invalid_score_fails_closed():
             subjects=["a", "b"],
             overrides={"interaction_strength": 1.2},
         )
+
+
+def test_non_boolean_contact_required_fails_closed():
+    with pytest.raises(ValueError, match="contact_required"):
+        extract_multi_subject_shot(
+            ShotLike(),
+            subjects=["a", "b"],
+            overrides={"contact_required": "yes"},
+        )


### PR DESCRIPTION
## Summary

Implements the deterministic multi-subject routing core tracked in #40 and connects it to StoryCore-style shot specifications without coupling the project to any video model.

### Routing core
- `DIRECT`, `PARALLEL`, and `SEQUENTIAL` generation strategies;
- deterministic inputs for subject count, interaction/contact, occlusion, identity criticality, camera motion, temporal dependency, and compute budget;
- strong contact/interaction/occlusion routes to staged sequential generation;
- independent identity-critical subjects can route to parallel generation/composition;
- simple or severely compute-constrained scenes retain the direct baseline;
- route decisions include confidence, reasons, and intermediate-validation requirements.

### Shot-spec adapter
- accepts dicts or existing dataclass-like StoryCore shot objects;
- subject count can come from `subject_count`, `characters_present`, `subjects`, an explicit subject list, or routing metadata;
- **all available subject-count sources must agree**; contradictory stale metadata fails closed rather than silently routing a multi-character scene as DIRECT;
- reads optional `metadata.multi_subject_routing` without changing the current core Shot dataclass;
- deterministically maps common camera-movement text (pan/tracking/orbit/handheld/etc.) to bounded intensity;
- orchestration can provide explicit overrides when scene context knows interaction/occlusion information;
- unknown subject count, invalid/non-finite scores, contradictory counts, or non-boolean contact metadata fail closed.

### Tests
Covers DIRECT/PARALLEL/SEQUENTIAL boundaries, camera-motion normalization, metadata overrides, fail-closed subject counting, contradictory count sources, non-finite score validation and ambiguous contact metadata.

## Boundary

This PR chooses generation topology only. It does not render/composite media and cannot bypass semantic, structural or temporal validators. Parallel and sequential paths explicitly require intermediate validation.

## Validation status

StoryCore currently has no general Python PR workflow; its GitHub Action is path-limited to `apps/storycore-harbour/**`. Keep this PR draft until the targeted Python tests are run locally/self-hosted. No new hosted GitHub workflow is added here.

Targeted command:
`pytest -q tests/test_multi_subject_router.py tests/test_shot_spec_router_adapter.py`

## Next step

Benchmark three fixed multi-subject fixtures against the DIRECT baseline using reproducible manifests.

Tracks #40.