### PR TITLE
chore(license): align npm metadata with MIT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "storycore-engine",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "electron"
   ],
   "author": "StoryCore Team",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/zedarvates/StoryCore-Engine/issues"


### PR DESCRIPTION
## Summary

- align the root `package.json` license field from `ISC` to `MIT`
- align only the root package entry in `package-lock.json` from `ISC` to `MIT`
- preserve every dependency version, resolved URL, integrity hash, and third-party license

Tracks #46.

## Owner intent and boundary

The repository owner confirmed on 2026-08-30 that the public StoryCore-Engine repository is intended to be licensed under MIT.

This metadata-only change does **not** license, expose, or grant rights to private/commercial Ultimate Odycer code or assets. It is independent of draft PR #44.

## Verification

- base: `main` at `5da07b1f2d64b7b1902ca7365f9121ed10789e99`
- head: `09ef8fe01e9764f8d091c3390ddec2a2c9bf49ee`
- exactly 2 changed files: `package.json`, `package-lock.json`
- exactly one changed line per file: `"license": "ISC"` → `"license": "MIT"`
- 2 additions, 2 deletions; no line-count changes
- JSON semantic comparison after removing the targeted root license field is identical
- lockfile dependency graph and integrity metadata are unchanged
- no dependency installation or lifecycle script was run

## Promotion gate

- [x] owner MIT intent recorded
- [x] metadata-only diff verified
- [x] independent from PR #44
- [ ] human review approves this PR
- [ ] merge is separately and explicitly authorized

Keep this PR in draft. Creating it does **not** authorize merge, package publication, or release.