### PR TITLE
fix(ci): remove stale GemReward gitlink

### DIFF
--- a/.github/workflows/repository-checkout-ci.yml
+++ b/.github/workflows/repository-checkout-ci.yml
@@ -1,0 +1,19 @@
+name: Repository Checkout CI
+
+on:
+  pull_request:
+    paths:
+      - 'GemReward-Service-Repo'
+      - '.gitmodules'
+      - '.github/workflows/repository-checkout-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Repairs the repository-level checkout defect tracked in #48 without restoring or disclosing any submodule URL.

- removes the stale `GemReward-Service-Repo` gitlink;
- keeps the already-versioned public `GemReward-Service-Staging/` tree unchanged;
- adds a minimal `actions/checkout@v4` proof workflow with `contents: read` only.

## Canonical-state evidence

- the gitlink was introduced in commit `cdb9231` on 2026-03-08 without a matching `.gitmodules` entry;
- repository history contains no `.gitmodules` entry for this path;
- no tracked source or workflow references `GemReward-Service-Repo`;
- the public repository already tracks the GemReward implementation under `GemReward-Service-Staging/`;
- later commit `41d4225` only advanced the opaque gitlink commit and did not establish valid submodule metadata.

This makes deletion—not URL reconstruction—the smallest non-secret-bearing repair.

## Validation

The PR's `Repository Checkout CI` job intentionally contains only `actions/checkout@v4`. A green run proves the repository can be checked out through the normal action without the semantic-prevalidator tarball workaround.

No private repository URL is added or exposed. No project code is changed.

Closes #48.